### PR TITLE
feat(nix): add nix packaging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,37 @@ A modern file copy utility written in Rust that provides visual feedback during 
 
 ## Installation
 
+### NixOS
+
+Several installation methods are available:
+
+1. Using Flakes (recommended):
+```bash
+# Install directly
+nix profile install github:gohm44/cpv
+
+# Or try without installing
+nix run github:gohm44/cpv
+```
+
+2. Through NixOS configuration:
+```nix
+# In configuration.nix
+{
+  inputs.cpv.url = "github:gohm44/cpv";
+  
+  environment.systemPackages = [ inputs.cpv.packages.${system}.default ];
+}
+```
+
+3. Using home-manager:
+```nix
+# In home.nix
+{
+  home.packages = [ inputs.cpv.packages.${pkgs.system}.default ];
+}
+```
+
 ### From source
 
 ```bash

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, stdenv
+, rustPlatform
+, pkg-config
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "cpv";
+  version = "0.1.0";
+
+  src = ./.;
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
+
+  meta = with lib; {
+    description = "A modern file copy utility with progress visualization";
+    homepage = "https://github.com/gohm44/cpv";
+    license = licenses.mit;
+    maintainers = [ ];
+    platforms = platforms.all;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,23 @@
         };
       in
       {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "cpv";
+          version = "0.1.0";
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          meta = with pkgs.lib; {
+            description = "A modern file copy utility with progress visualization";
+            homepage = "https://github.com/gohm44/cpv";
+            license = licenses.mit;
+            maintainers = [ ];
+          };
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             rustToolchain


### PR DESCRIPTION
Add multiple ways to install cpv in NixOS:
- Add package definition to flake.nix
- Create default.nix for traditional nix packaging
- Document installation methods in README
- Support system-wide and user installation